### PR TITLE
Allow lumi-doc-download to download terms

### DIFF
--- a/se_code/doc_downloader.py
+++ b/se_code/doc_downloader.py
@@ -10,7 +10,7 @@ logger.setLevel(logging.INFO)
 
 
 def download_docs(project, batch_size=25000,
-                  doc_fields=('title', 'text', 'subsets', 'predict', 'date')):
+                  doc_fields=('title', 'text', 'terms', 'subsets', 'predict', 'date')):
     """
     Download all of the documents from a given project, given a LuminosoClient
     object pointed at that project.


### PR DESCRIPTION
When I use the `lumi-doc-download` script to download a project in .jsons format, I often need each document to be analyzed into terms. Here, I've added  `'terms'` as one of the default `doc_fields` so that the CLI tool can get them.