### PR TITLE
Add call to purge older messages

### DIFF
--- a/se_code/stream-messages.py
+++ b/se_code/stream-messages.py
@@ -39,6 +39,7 @@ BATCH_SIZES = [i for i in range(1, 16)]
 # Default number of seconds to wait between requests (0-10, inclusive)
 INTERVALS = [i for i in range(11)]
 
+# Compass, by way of Arrow, expects this date format to filter messages
 DATE_FMT = '%Y-%m-%dT%H:%M:%S'
 
 


### PR DESCRIPTION
This script post messages to the so-called "Evergreen" project to simulate a live Compass project that creates a new batch of  unsupervised topics at regular intervals, so sales people will have something to demo. As messages (and classifications) accumulate, the old and tired UI becomes more an more unresponsive.

The present modification adds a step that will delete messages (and classifications) older than a day every time it `POST`s a batch of messages. It does so via the little-know (and undocumented) `/purge` endpoint.