### PR TITLE
Performance Tuning for Subset Key Terms

### DIFF
--- a/se_code/subset_key_terms.py
+++ b/se_code/subset_key_terms.py
@@ -6,7 +6,7 @@ import argparse, csv, sys, getpass
 import concurrent.futures
 
 
-def subset_key_terms(client, api_url, account, project, terms_per_subset=10, scan_terms=1000):
+def subset_key_terms(client, terms_per_subset=10, scan_terms=1000):
     """
     Find 'key terms' for a subset, those that appear disproportionately more
     inside a subset than outside of it. We determine this using Fisher's
@@ -32,7 +32,7 @@ def subset_key_terms(client, api_url, account, project, terms_per_subset=10, sca
     results = []
     with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
 
-        futures = {executor.submit(skt, subset, scan_terms, subset_counts, pvalue_cutoff, api_url, account, project): subset for subset in sorted(subset_counts)}
+        futures = {executor.submit(skt, client, subset, scan_terms, subset_counts, pvalue_cutoff): subset for subset in sorted(subset_counts)}
         for future in concurrent.futures.as_completed(futures):
             subset_scores = future.result()
 
@@ -41,8 +41,7 @@ def subset_key_terms(client, api_url, account, project, terms_per_subset=10, sca
     return results
 
 
-def skt(subset, scan_terms, subset_counts, pvalue_cutoff, api_url, account, project):
-    client = LuminosoClient.connect(url='{}/projects/{}/{}'.format(api_url, account, project))
+def skt(client, subset, scan_terms, subset_counts, pvalue_cutoff):
     subset_terms = client.get('terms', subset=subset, limit=scan_terms)
     length = 0
     termlist = []

--- a/se_code/tableau_export.py
+++ b/se_code/tableau_export.py
@@ -94,7 +94,7 @@ def pull_lumi_data(account, project, api_url, skt_limit, term_count=100, interva
     topics = client.get('topics')
     themes = client.get('/terms/clusters/', num_clusters=themes, num_cluster_terms=theme_terms)
     terms = client.get('terms', limit=term_count)
-    skt = subset_key_terms(client, api_url, account, project, terms_per_subset=skt_limit)
+    skt = subset_key_terms(client, terms_per_subset=skt_limit)
 
     drivers = list(set([key for d in docs for key in d['predict'].keys()]))
     exist_flag = True


### PR DESCRIPTION
I introduced multi-threading with concurrent.futures to improve the performance of Subset Key Terms aka SKT.
With this PR, SKT will be 240% faster than the current version against a 2,000 documents project.

- master: 85.242 sec
- this PR: 25.103 sec

In this code, LuminosoClient object is created in each thread, because requests.Session is not 100% threadsafe.