### PR TITLE
Reduce time interval of waiting_for_jobs() from 30 sec to 1 sec

### DIFF
--- a/se_code/tableau_export.py
+++ b/se_code/tableau_export.py
@@ -345,11 +345,17 @@ def wait_for_jobs(client, text):
     :return: None
     '''
 
+    check_interval = 1
     time_waiting = 0
+
     while len(client.get()['running_jobs']) != 0:
         sys.stderr.write('\r\tWaiting for {} ({}sec)'.format(text, time_waiting))
-        time.sleep(30)
-        time_waiting += 30
+        sys.stderr.flush()
+        time.sleep(check_interval)
+        time_waiting += check_interval
+
+    if time_waiting > 0:
+        sys.stderr.write('\n')
 
 
 def add_score_drivers_to_project(client, docs, drivers):


### PR DESCRIPTION
This PR reduces polling time in waiting_for_jobs().

30 seconds interval is too long, especially for a small project.
In this PR, the interval time is changed to 1 second to improve performance.