### PR TITLE
Ignore blank text format multiple

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2020 Luminoso Technologies, Inc.
+Copyright (c) 2015-2021 Luminoso Technologies, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Navigate your browser to (http://127.0.0.1:5000/)
 
 ##  Packaging the wheel file for customers
 
-The se_code can be packaged for sharing with customers by using a wheel file.
+The se_code can be packaged for sharing with customers by using a wheel file. First update the version in the setup.py file.
 
 `cd sales-engineering-code`
 `python setup.py sdist bdist_wheel`

--- a/se_code/create_daylight_project_from_csv.py
+++ b/se_code/create_daylight_project_from_csv.py
@@ -1,11 +1,12 @@
 from luminoso_api import V5LuminosoClient as LuminosoClient
+from ignore_terms import ignore_csv_file
 
 import argparse
 import datetime, getpass, time, json, os, csv
 import numpy, pack64
 
 '''
-Create a Luminoso Daylight project from a CSV file. Usefull if the file is too 
+Create a Luminoso Daylight project from a CSV file. Usefull if the file is too
 large for UI or building without the UI for things like search_enhancement
 
 '''
@@ -17,8 +18,18 @@ def write_documents(client,docs):
         result = client.post('upload', docs=docs[offset:end])
         offset = end
 
+
+def is_number(s):
+    try:
+        float(s)
+        return True
+    except ValueError:
+        return False
+
+
 def create_project(client, input_file, project_name, account_id, keyword_expansion_terms=None, max_len=0, skip_sentiment_build=False):
-    
+
+    doc_count = 0
     block_size = 5000
 
     # create the project
@@ -50,8 +61,8 @@ def create_project(client, input_file, project_name, account_id, keyword_expansi
                 if ksplit[0].lower().strip() == 'date':
                     try:
                         if len(row[k])>0:
-                            if (row[k].isnumeric()):
-                                edate = int(row[k])
+                            if (is_number(row[k])):
+                                edate = int(float(row[k]))
                             else:
                                 date_formats = ["%Y-%m-%dT%H:%M:%SZ","%Y-%m-%d","%m/%d/%Y","%m/%d/%y","%m/%d/%y %H:%M"]
                                 edate = None
@@ -64,33 +75,34 @@ def create_project(client, input_file, project_name, account_id, keyword_expansi
                                     print("Error in date format: {}".format(row[k]))
                                     print("{} is numeric {}".format(row[k],row[k].isnumeric()))
                                 else:
-                                    new_doc['metadata'].append({"type":ksplit[0],"name":field_name,"value":edate})
+                                    new_doc['metadata'].append({"type":ksplit[0].lower().strip(),"name":field_name,"value":edate})
                     except:
                         print("date error: {}".format(row[k]))
                 elif ksplit[0].lower().strip() in 'number':
                     try:
-                        new_doc['metadata'].append({"type":ksplit[0],"name":field_name,"value":float(row[k].strip()) if row[k].strip() else 0})                
+                        new_doc['metadata'].append({"type":ksplit[0].lower().strip(),"name":field_name,"value":float(row[k].strip()) if row[k].strip() else 0})
                     except:
                         print("number error")
                 elif ksplit[0].lower().strip() in 'score':
                     try:
-                        new_doc['metadata'].append({"type":ksplit[0],"name":field_name,"value":float(row[k].strip()) if row[k].strip() else 0})
+                        new_doc['metadata'].append({"type":ksplit[0].lower().strip(),"name":field_name,"value":float(row[k].strip()) if row[k].strip() else 0})
                     except:
                         print("score error")
                 elif ksplit[0] in lumi_data_types:
-                    new_doc['metadata'].append({"type":ksplit[0],"name":field_name,"value":row[k]})
+                    new_doc['metadata'].append({"type":ksplit[0].lower().strip(),"name":field_name,"value":row[k]})
         docs.append(new_doc)
 
         if len(docs)>=block_size:
-            print("Uploading {} documents".format(len(docs)))
+            print("Uploading {} documents at {}".format(len(docs),doc_count))
             write_documents(client_prj, docs)
-
+            doc_count += len(docs)
             docs = []
-    
+
     if len(docs)>0:
         print("Uploading {} documents".format(len(docs)))
         write_documents(client_prj, docs)
-    
+        doc_count += len(docs)
+
     sentiment_configuration = {"type":"full"}
     if (skip_sentiment_build):
         sentiment_configuration = {"type":"none"}
@@ -111,11 +123,11 @@ def create_project(client, input_file, project_name, account_id, keyword_expansi
         print("keyword filter = {}".format(keyword_expansion_dict))
 
         client_prj.post("build",
-                keyword_expansion=keyword_expansion_dict, 
+                keyword_expansion=keyword_expansion_dict,
                 sentiment_configuration=sentiment_configuration)
     else:
         client_prj.post('build', sentiment_configuration=sentiment_configuration)
-    
+
     print("Build started")
 
     return client_prj
@@ -132,8 +144,9 @@ def main():
     parser.add_argument('-m', '--max_text_length', default="0", required=False, help="The maximum length to limit text fields")
     parser.add_argument('-s', '--skip_sentiment_build', action="store_true", default=False, help="Allows the build to skip the sentiment build")
     parser.add_argument('-w', '--wait_for_build_complete', action="store_true", default=False, help="Wait for the build to complete")
+    parser.add_argument('-i', '--ignore_terms_csv_file', default=None, required=False, help="A csv file with terms to ignore")
     args = parser.parse_args()
-    
+
     project_name = args.project_name
     input_file = args.input_file
     account_id = args.account_id
@@ -155,13 +168,31 @@ def main():
         else:
             print("error retrieving account_id: {}".format(profile['error']))
 
+    # the ignore terms will cause a second build and doesn't need sentiment built
+    save_skip_sentiment_build = args.skip_sentiment_build
+    if args.ignore_terms_csv_file:
+        args.skip_sentiment_build = True
+
     # connect to v5 api
     client = LuminosoClient.connect(url=api_url, user_agent_suffix='se_code:create_daylight_project_from_csv')
 
     client_prj = create_project(client, input_file, project_name, account_id, keyword_expansion_terms=args.keyword_expansion_terms, max_len=max_len, skip_sentiment_build=args.skip_sentiment_build)
 
-    if (args.wait_for_build_complete):
+    if (args.wait_for_build_complete or args.ignore_terms_csv_file):
         print("waiting for build to complete...")
+        client_prj.wait_for_build()
+
+    if args.ignore_terms_csv_file:
+        print("Ignoring terms from: "+args.ignore_terms_csv_file)
+        ignore_csv_file(args.ignore_terms_csv_file,client_prj)
+
+        sentiment_configuration = {"type":"full"}
+        if (save_skip_sentiment_build):
+            sentiment_configuration = {"type":"none"}
+
+        client_prj.post('build',
+            sentiment_configuration=sentiment_configuration)
+        print("Waiting for ignore terms build")
         client_prj.wait_for_build()
 
 if __name__ == '__main__':

--- a/se_code/format_multiple_text_fields.py
+++ b/se_code/format_multiple_text_fields.py
@@ -1,13 +1,33 @@
 import csv
 import argparse
 
+
 def file_to_dict(file_name, encoding="utf-8"):
     table = []
     with open(file_name, encoding=encoding) as f:
-        reader = csv.DictReader(f)
+        reader = csv.reader(f)
+
+        # found some csv files have same name columns
+        # map and change those to unique names so can still use as dict
+        raw_header = next(reader)
+        header_map = {}
+        header = []
+        for name in raw_header:
+            if name in header:
+                idx = 2
+                new_name = "{}_{}".format(name, idx)
+                while new_name in header:
+                    idx += 1
+                    new_name = "{}_{}".format(name, idx)
+                header_map[new_name] = name
+
+                name = new_name
+            header.append(name)
+
         for row in reader:
-            table.append(row)
-    return table
+            table.append(dict(zip(header, row)))
+    return table, header_map
+
 
 def file_to_list(file_name, encoding="utf-8"):
     table = []
@@ -16,26 +36,35 @@ def file_to_list(file_name, encoding="utf-8"):
         for row in reader:
             table.append(row)
     return table
-    
-def dict_to_file(table, file_name, encoding="utf-8"):
+
+
+def dict_to_file(table, file_name, encoding="utf-8", header_map={}):
     fields = []
     for key in table[0]:
-        fields.append(key)
+        if key in header_map:
+            fields.append(header_map[key])
+        else:
+            fields.append(key)
+
     with open(file_name, 'w', newline='', encoding=encoding) as f:
-        writer = csv.DictWriter(f, fields)
-        writer.writeheader()
-        writer.writerows(table)
-        
+        writer = csv.writer(f)
+        writer.writerow(fields)
+        for row in table:
+            writer.writerow(row.values())
+
+
 def list_to_file(table, file_name, encoding="utf-8"):
     with open(file_name, 'w', newline='', encoding=encoding) as f:
         writer = csv.writer(f)
         writer.writerows(table)
-        
+
+
 def char_position(letters):
     index = 0
     for i, char in enumerate(letters):
         index += ((ord(char.lower()) - 97) + (i * 26))
     return index
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -61,7 +90,7 @@ def main():
     args = parser.parse_args()
     
     write_table = []
-    table = file_to_dict(args.input_file, encoding=args.encoding)
+    table, header_map = file_to_dict(args.input_file, encoding=args.encoding)
     text_fields = [field for field in table[0] if 'text_' in field.lower() or 'text' == field.lower().strip()]
     for read_row in table:
         for key in read_row:
@@ -73,7 +102,8 @@ def main():
                 else:
                     write_row.update({'string_' + args.column_dest: 'Text'})
                 write_table.append(write_row)
-    dict_to_file(write_table, args.output_file, encoding=args.encoding)
-    
+    dict_to_file(write_table, args.output_file, encoding=args.encoding, header_map=header_map)
+
+
 if __name__ == '__main__':
     main()

--- a/se_code/format_multiple_text_fields.py
+++ b/se_code/format_multiple_text_fields.py
@@ -98,10 +98,11 @@ def main():
                 write_row = {k: v for k, v in read_row.items() if k not in text_fields}
                 write_row.update({'Text': read_row[key]})
                 if 'text_' in key.lower():
-                    write_row.update({'string_' + args.column_dest: key.split('ext_')[1]})
+                    write_row.update({'string_' + args.column_dest: key.split('text_')[1]})
                 else:
                     write_row.update({'string_' + args.column_dest: 'Text'})
-                write_table.append(write_row)
+                if len(write_row['Text'].strip()) > 0:
+                    write_table.append(write_row)
     dict_to_file(write_table, args.output_file, encoding=args.encoding, header_map=header_map)
 
 

--- a/se_code/ignore_terms.py
+++ b/se_code/ignore_terms.py
@@ -39,6 +39,9 @@ def ignore_multiple_terms(texts, client):
     ignore = client.get('terms/manage')
     return ignore
         
+def ignore_csv_file(filename, client):
+        texts = read_csv_file(filename)
+        ignore = ignore_multiple_terms(texts, client)
 
 def main():
     parser = argparse.ArgumentParser(
@@ -55,8 +58,7 @@ def main():
     if args.ignore_term:
         ignore = ignore_single_term(args.ignore_term, client)
     elif args.filename:
-        texts = read_csv_file(args.filename)
-        ignore = ignore_multiple_terms(texts, client)
+        ignore_csv_file(args.filename, client)
     else:
         ignore_term = ''
         while ignore_term.strip() == '':

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="se_code",
-    version='0.2',
+    version='0.3c',
     maintainer='Luminoso Technologies, Inc.',
     maintainer_email='dev@luminoso.com',
     license="LICENSE",


### PR DESCRIPTION
Simple change to ignore blank text entries on format_multiple_text_fields. One of our CSMs was having to do a lot of manual work an this will save them a lot of time.  I didn't realize there were a couple other changes that snuck into this branch.  Also includes changes to upload projects from csv to deal with language and a customer simplification to allow an ignore terms file when creating a project which would previously have taken two separate commands.