### PR TITLE
Improve ignore terms

### DIFF
--- a/se_code/ignore_terms.py
+++ b/se_code/ignore_terms.py
@@ -1,6 +1,9 @@
 from luminoso_api import V5LuminosoClient as LuminosoClient
 
-import json, csv, argparse
+import argparse
+import csv
+import json
+import sys
 
 
 def parse_url(url):
@@ -9,45 +12,38 @@ def parse_url(url):
     return api_root + '/api/v5/projects/' + proj_id
 
 
-def ignore_single_term(text, client):
-    concept = client.get(
-        'concepts',
-        concept_selector={'type': 'specified', 'concepts': [{'texts': [text]}]}
-    )
-    if concept['result'] > 0:
-        if concept['result'][0]['exact_term_ids']:
-            ignore_term = concept['result'][0]['exact_term_ids'][0]
-            client.put('terms/manage',
-                       term_management={ignore_term: {'action': 'ignore'}})
-            ignore = client.get('terms/manage')
-        else:
-            print("ERROR no term: {}".format(text))
-            ignore = "ERROR"
-    else:
-        print("ERROR invalid results: {}".format(text))
-        ignore = "ERROR"
-    return ignore
-
-
 def read_csv_file(filename):
     with open(filename, 'r', encoding='utf-8-sig') as f:
-        reader = csv.DictReader(f)
-        table = [row for row in reader]
-    return [t['text'] for t in table]
+        return [row['text'] for row in csv.DictReader(f)]
 
 
-def ignore_multiple_terms(texts, client):
-    concepts = [{'texts': [t]} for t in texts]
-    concept = client.get(
+def read_text_file(filename):
+    with open(filename, 'r', encoding='utf-8-sig') as f:
+        return f.readlines()
+
+
+def ignore_terms(texts, client):
+    # Get the current state of management, so we can see whether there are
+    # changes by the end
+    current_management = client.get('terms/manage')
+    selector = [{'texts': [t]} for t in texts]
+    concepts = client.get(
         'concepts',
-        concept_selector={'type': 'specified', 'concepts': concepts}
+        concept_selector={'type': 'specified', 'concepts': selector}
     )['result']
-    ignore_terms = [c['exact_term_ids'][0] for c in concept
-                    if c['exact_term_ids']]
-    terms = {t: {'action': 'ignore'} for t in ignore_terms}
-    client.put('terms/manage', term_management=terms)
-    ignore = client.get('terms/manage')
-    return ignore
+
+    to_ignore = {}
+    for concept in concepts:
+        exact_term_ids = concept['exact_term_ids']
+        if exact_term_ids:
+            to_ignore[exact_term_ids[0]] = {'action': 'ignore'}
+    if not to_ignore:
+        raise ValueError('No concepts found')
+    client.put('terms/manage', term_management=to_ignore)
+    new_management = client.get('terms/manage')
+    if new_management == current_management:
+        raise ValueError('No changes detected')
+    return new_management
 
 
 def main():
@@ -56,11 +52,17 @@ def main():
     )
     parser.add_argument('project_url',
                         help="URL of the project to ignore terms in")
-    parser.add_argument('-i', '--ignore_term', default=None,
-                        help="Term to ignore in project")
-    parser.add_argument('-f', '--filename', default=None,
-                        help=("Name of the file to read list of terms to"
-                              " ignore from"))
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-i', '--ignore_term', default=None, action='append',
+                        help=('Term to ignore in project; can be specified'
+                              ' multiple times'))
+    group.add_argument('-f', '--filename', default=None,
+                        help=('Name of the file to read list of terms to'
+                              ' ignore from.  If the filename ends with .csv,'
+                              ' concepts will be read from the "text" column.'
+                              '  Otherwise, each line of the file will be'
+                              ' treated as a concept to ignore'))
     args = parser.parse_args()
 
     endpoint = parse_url(args.project_url)
@@ -68,20 +70,25 @@ def main():
                                     user_agent_suffix='se_code:ignore_terms')
 
     if args.ignore_term:
-        ignore = ignore_single_term(args.ignore_term, client)
+        terms_to_ignore = args.ignore_term
     elif args.filename:
-        texts = read_csv_file(args.filename)
-        ignore = ignore_multiple_terms(texts, client)
+        if args.filename.endswith('.csv'):
+            terms_to_ignore = read_csv_file(args.filename)
+        else:
+            terms_to_ignore = read_text_file(args.filename)
     else:
         ignore_term = ''
         while ignore_term.strip() == '':
             ignore_term = input('No term specified, please input a term now: ')
-        ignore = ignore_single_term(ignore_term, client)
+        terms_to_ignore = [ignore_term]
 
-    print("{}".format(
-        json.dumps(ignore, ensure_ascii=False, indent=2).encode('utf8').decode()
-    ))
+    try:
+        ignore_result = ignore_terms(terms_to_ignore, client)
+    except ValueError as e:
+        print(f'Error encountered: {e}.  Not rebuilding!')
+        sys.exit()
 
+    print(json.dumps(ignore_result, ensure_ascii=False, indent=2))
     client.post('build')
     client.wait_for_build()
     print('Project rebuilt, terms ignored')


### PR DESCRIPTION
Some of the changes are Pythonic/PEP8 things; others include (per second commit)

* Allow either a CSV file or a text file to be specified with -f

* Use one code branch regardless of the number of terms being ignored, rather than separate branches for one vs. multiple

* Quit without building, printing an error message, if (a) there are no concepts specified (e.g. only stopwords are specified) or (b) there are no changes that result from ignoring the specified concepts (e.g. they were all already being ignored)

* Make "-i" and "-f" mutually exclusive; the code was already treating them that way (ignoring "-f" if "-i" was specified), but silently

